### PR TITLE
Added link to documentation to README

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@
 
 Requirements:
 
-  * Python 2.5 or newer. (not tested on older versions)
+  * Python 2.5+. (not compatible with Python 3; not tested on older versions)
   * Bob Ippolito's simplejson module, if using Python < 2.6
     <http://pypi.python.org/pypi/simplejson>
   * To upload files or import XML, you need Chris AtLee's poster package


### PR DESCRIPTION
The link to the documentation (https://code.google.com/p/python-wikitools/wiki/Documentation) was not present anywhere in the repository; I added it to README.md. 
