### PR TITLE
Fix Wiki.getToken() where the response has no data sector

### DIFF
--- a/wikitools/wiki.py
+++ b/wikitools/wiki.py
@@ -321,8 +321,12 @@ class Wiki:
 			}
 			req = api.APIRequest(self, params)
 			response = req.query(False)
-			pid = response['data']['query']['pages'].keys()[0]
-			token = response['query']['pages'][pid]['edittoken']
+			if response.get('data', False):
+				pid = response['data']['query']['pages'].keys()[0]
+				token = response['query']['pages'][pid]['edittoken']
+			else:
+				pages = response['query']['pages']
+				token = pages.itervalues().next()['edittoken']
 		return token
 
 


### PR DESCRIPTION
I found a case where using an older (1.20) version of MediaWiki, and attempting to upload a single file, the Wiki.getToken() response does not include any data section. The getToken() then fails with KeyError: 

'''
Traceback (most recent call last):
  File "WikiUploadPDF.py", line 31, in <module>
    page.upload(f, "{{Template summary}}")
  File "/usr/local/lib/python2.7/dist-packages/wikitools/wikifile.py", line 229, in upload
    'token':self.site.getToken('csrf')
  File "/usr/local/lib/python2.7/dist-packages/wikitools/wiki.py", line 324, in getToken
    pid = response['data']['query']['pages'].keys()[0]
KeyError: 'data'
'''

The response I do get back from the api.APIRequest() call is:
'''
{u'query': {u'pages': {u'3800': {u'lastrevid': 18992, u'pageid': 3800, u'title': u'1', u'starttimestamp': u'2015-04-27T02:24:56Z', u'counter': 358, u'edittoken': u'<token>', u'length': 96, u'touched': u'2015-04-14T12:50:09Z', u'ns': 0}}}}
'''

So I fix this by checking if the data section is present, and extracting the first pid edittoken if not. 