### PR TITLE
Add a getEntities function

### DIFF
--- a/wikitools/page.py
+++ b/wikitools/page.py
@@ -553,6 +553,30 @@ class Page(object):
 			rvc = response['continue']
 		return (revs, rvc)
 	
+	def getEntities(self,sites='enwiki',ids=False,languages='en',props='all'):
+		"""Get the entities on a wikidata page
+		https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities
+		"""
+		params = {
+			'action':'wbgetentities',
+			'languages':languages
+		}
+		if self.title:
+			params['titles'] = self.title
+		if ids:
+			params['ids'] = ids
+		if sites:
+			params['sites'] = sites
+		if props == 'all':
+			params['props'] = 'info|sitelinks|aliases|labels|descriptions|claims|datatype'
+		else:
+			params['props'] = props
+		
+		req = api.APIRequest(self.site, params)
+		response = req.query(False)
+		
+		return response
+	
 	def __extractToList(self, json, stuff):
 		list = []
 		if self.pageid == 0:


### PR DESCRIPTION
This (very roughly) implements a `getEntities` function to retrieve semantic data from a WikiData-like site. Example:

```
import wikitools as wt
wikidata_site = wt.wiki.Wiki(url='https://www.wikidata.org/w/api.php')
wt.page.Page(site=wikidata_site,title='2016 Central Italy earthquake',followRedir=False).getEntities()
```
